### PR TITLE
Update stollie.css

### DIFF
--- a/css/stollie.css
+++ b/css/stollie.css
@@ -23,3 +23,11 @@
         width: 1600px !important;
     }
 }
+
+ol li {
+    font-weight: bold;
+}
+
+ol li p {
+    font-weight: normal;
+}


### PR DESCRIPTION
Fix for issue `Make enumerations bold #14`
Couldn't use the ::marker pseudo-element, because that is unavailable in Chrome and Edge.